### PR TITLE
Enable automatic GitHub Pages deployment

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,39 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run build -- --base=/afc-rapports-bdd/
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./dist
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -54,3 +54,7 @@ npm run dev
 ```sh
 npm run lint
 ```
+## Déploiement sur GitHub Pages
+
+Un workflow GitHub Actions (`.github/workflows/pages.yml`) construit automatiquement l'application et la publie sur GitHub Pages à chaque push sur `main`.
+Activez GitHub Pages dans les paramètres du dépôt pour rendre l'application accessible à l'URL fournie par l'action.


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to build the app and deploy to GitHub Pages
- document the automatic deployment in README

## Testing
- `npm run lint` *(fails: Invalid option '--ignore-path' and lint errors)*
- `npm run build -- --base=/afc-rapports-bdd/`

------
https://chatgpt.com/codex/tasks/task_e_68492d3768d88327a07a8d24f05ee3b7