### PR TITLE
Fix GitHub Pages base path

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -23,7 +23,9 @@ jobs:
         with:
           node-version: 20
       - run: npm install
-      - run: npm run build -- --base=/afc-rapports-bdd/
+      - run: npm run build
+        env:
+          BASE_PATH: /afc-rapports-bdd/
       - uses: actions/upload-pages-artifact@v3
         with:
           path: ./dist

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,6 +6,7 @@ import vueDevTools from 'vite-plugin-vue-devtools'
 
 // https://vitejs.dev/config/
 export default defineConfig({
+  base: process.env.BASE_PATH ?? '/',
   plugins: [
     vue(),
     vueDevTools(),


### PR DESCRIPTION
## Summary
- allow customizing the Vite base path using `BASE_PATH`
- set `BASE_PATH` in the GitHub Pages workflow

## Testing
- `npm run build`
- `npm run lint` *(fails: Elements in iteration expect to have 'v-bind:key' directives, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_684983cb17b083279d2fedb35043811f